### PR TITLE
Global filter state for hailpad data

### DIFF
--- a/apps/client/src/components/hailgen/hailpad-details.tsx
+++ b/apps/client/src/components/hailgen/hailpad-details.tsx
@@ -199,7 +199,7 @@ export default function HailpadDetails({
                                         <SettingsIcon />
                                     </Button>
                                 </PopoverTrigger>
-                                <PopoverContent className="w-76">
+                                <PopoverContent className="w-80">
                                     <div className="space-y-4">
                                         <div className="mb-6">
                                             <p className="text-lg font-semibold">View</p>


### PR DESCRIPTION
This pull request uses a shared external store for filter state management in usePadAll, so that filter updates made in `hailpad-details` updates across `hailpad-map` and `dent-details` as well.